### PR TITLE
Add user-specifiable release_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ resources:
 
 * `repository`: *Required.* The GitHub repository of the release, i.e.
 `username/reponame`.
-
+* `release_version`: Optional. Lock to a specific release version. Must be a string (enclose in "quotes"). Used only when downloading releases during in.
 
 ## Behavior
 
@@ -26,9 +26,11 @@ resources:
 
 Detects new versions of the release that have been published to bosh.io.
 
+If a `release_version` is specified it will always be returned as
+lastest.
+
 Note that there may be a delay between the final release appearing on
 GitHub, and it appearing in bosh.io.
-
 
 ### `in`: Fetch a version of the release.
 

--- a/assets/check
+++ b/assets/check
@@ -15,6 +15,12 @@ cat > $payload <&0
 
 repository=$(jq -r '.source.repository // ""' < $payload)
 current_version=$(jq -r '.version.version // ""' < $payload)
+release_version=$(jq -r '.source.release_version // ""' < $payload)
+
+if [ -z "$release_version" ]; then
+  echo "Getting with user-specified release_version: ${release_version}."
+  $current_version=$release_version
+fi
 
 if [ -z "$repository" ]; then
   echo "must specify source repository"


### PR DESCRIPTION
- This allows users to pull in a specific release for use in pipelines

Signed-off-by: Zachary Gershman zgershman@pivotal.io
