### PR TITLE
Add SHA1 to output of in script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Fetches a given release, placing the following in the destination:
 
 * `version`: The version number of the release.
 * `url`: A URL that can be used to download the release tarball.
+* `sha1`: The sha1 of the release tarball.
 * `release.tgz`: The release tarball, if the `tarball` param is `true`.
 
 #### Parameters

--- a/assets/in
+++ b/assets/in
@@ -34,9 +34,21 @@ fi
 mkdir -p $destination
 
 download_url="https://bosh.io/d/github.com/${repository}?v=${version}"
+sha1=$(
+  curl \
+    --retry 5 \
+    --fail \
+    --location \
+    "https://bosh.io/api/v1/releases/github.com/${repository}" \
+  | jq \
+    --raw-output \
+    --arg version $version \
+    '.[] | select(.version==$version) | .sha1 // ""'
+  )
 
 echo "$download_url" > $destination/url
 echo "$version" > $destination/version
+echo "$sha1" > $destination/sha1
 
 if [ "$fetch_tarball" = "true" ]; then
   curl --retry 5 --fail -L "$download_url" -o $destination/release.tgz
@@ -47,6 +59,6 @@ jq -n '{
     version: $version
   },
   metadata: [
-    {name: "url", value: $url}
+    {name: "url", value: $url, sha1: $sha1}
   ]
-}' --arg version "$version" --arg url "$download_url" >&3
+}' --arg version "$version" --arg url "$download_url" --arg sha1 "$sha1" >&3


### PR DESCRIPTION
Should be able to close https://github.com/concourse/bosh-io-release-resource/issues/6 when this is merged.
