### PR TITLE
Support custom bosh.io server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ resources:
 
 * `repository`: *Required.* The GitHub repository of the release, i.e.
 `username/reponame`.
+* `server`: Default `https://bosh.io`. The bosh-hub server to query.
 
 
 ## Behavior

--- a/assets/check
+++ b/assets/check
@@ -13,6 +13,7 @@ payload=$(mktemp $TMPDIR/bosh-io-release-resource-request.XXXXXX)
 
 cat > $payload <&0
 
+server=$(jq -r '.source.server // "https://bosh.io"' < $payload)
 repository=$(jq -r '.source.repository // ""' < $payload)
 current_version=$(jq -r '.version.version // ""' < $payload)
 
@@ -23,7 +24,7 @@ fi
 
 releases=$(mktemp $TMPDIR/bosh-io-release-versions.XXXXXX)
 
-curl --retry 5 -L -s -f https://bosh.io/api/v1/releases/github.com/$repository -o $releases
+curl --retry 5 -L -s -f $server/api/v1/releases/github.com/$repository -o $releases
 
 last_idx=0
 if [ -z "$current_version" ]; then

--- a/assets/in
+++ b/assets/in
@@ -10,6 +10,7 @@ payload=$(mktemp $TMPDIR/bosh-io-release-resource-request.XXXXXX)
 
 cat > $payload <&0
 
+server=$(jq -r '.source.server // "https://bosh.io"' < $payload)
 repository=$(jq -r '.source.repository // ""' < $payload)
 version=$(jq -r '.version.version // ""' < $payload)
 fetch_tarball=$(jq -r '.params.tarball != false' < $payload)
@@ -40,7 +41,7 @@ curl \
   --retry 5 \
   --fail \
   --location \
-  "https://bosh.io/api/v1/releases/github.com/${repository}" | \
+  "$server/api/v1/releases/github.com/${repository}" | \
   jq 'map(select(.version == $version))[0]' --arg version "$version" > \
   $release_data
 

--- a/assets/in
+++ b/assets/in
@@ -46,7 +46,7 @@ curl \
   $release_data
 
 url="$(jq -r .url < $release_data)"
-sha1="$(jq -r .sha1 < $release_data)"
+sha1="$(jq -r '.sha1 // ""' < $release_data)"
 
 if [ "$url" = "null" ]; then
   echo "version $version not found; aborting"
@@ -60,7 +60,9 @@ echo "$sha1" > $destination/sha1
 if [ "$fetch_tarball" = "true" ]; then
   pushd $destination >/dev/null
     curl --retry 5 --fail -L "$url" -o release.tgz
-    echo "$sha1  release.tgz" | sha1sum -c -
+    if [ -n "$sha1" ] ; then
+      echo "$sha1  release.tgz" | sha1sum -c -
+    fi
   popd >/dev/null
 fi
 


### PR DESCRIPTION
For the desired use case of supporting custom, bosh.io-compatible endpoints and helping with pipeline testing.

Also includes a commit which excludes sha1 testing if the field was missing or empty. Happy to take that commit out if you disagree with that. Was intended more for symmetry with a followup PR I'll make to stemcells where sha1 was only recently added.
