### PR TITLE
Add support for fetching specific versions of releases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ resources:
 
 * `repository`: *Required.* The GitHub repository of the release, i.e.
 `username/reponame`.
+* `regexp`: *Optional* A regular expression matching the version(s) to fetch, i.e.
+`13.*`.
 
 
 ## Behavior

--- a/assets/check
+++ b/assets/check
@@ -14,6 +14,7 @@ payload=$(mktemp $TMPDIR/bosh-io-release-resource-request.XXXXXX)
 cat > $payload <&0
 
 repository=$(jq -r '.source.repository // ""' < $payload)
+regexp=$(jq -r '.source.regexp // ""' < $payload)
 current_version=$(jq -r '.version.version // ""' < $payload)
 
 if [ -z "$repository" ]; then
@@ -21,9 +22,14 @@ if [ -z "$repository" ]; then
   exit 1
 fi
 
+if [ -z "$regexp" ]; then
+  regexp=".*"
+fi
+
 releases=$(mktemp $TMPDIR/bosh-io-release-versions.XXXXXX)
 
-curl --retry 5 -L -s -f https://bosh.io/api/v1/releases/github.com/$repository -o $releases
+curl --retry 5 -L -s -f https://bosh.io/api/v1/releases/github.com/$repository \
+  | jq '[.[] | select (.version | test($v))]' --arg v "$regexp" > $releases
 
 last_idx=0
 if [ -z "$current_version" ]; then

--- a/spec/check_spec.rb
+++ b/spec/check_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'json'
 
 RSpec.describe 'check' do
-  def check(repo, version = nil)
+  def check(repo, version = nil, regexp = nil)
     payload = {
       source: {
         repository: repo
@@ -11,6 +11,10 @@ RSpec.describe 'check' do
 
     if version
       payload[:version] = { version: version }
+    end
+
+    if regexp
+      payload[:source][:regexp] = regexp
     end
 
     output = `echo '#{payload.to_json}' | /opt/resource/check`
@@ -44,6 +48,34 @@ RSpec.describe 'check' do
       expect(versions.length).to eq 1
       expect(versions.first).to have_key("version")
       expect(versions.first["version"]).to match /^\d+\.\d+\.\d+$/
+    end
+  end
+
+  context 'when a regexp is provided with no last known version' do
+    it 'produces the latest version matching the expression' do
+      versions = check('concourse/concourse', nil, '3.14.*')
+
+      expect(versions.length).to eq 1
+      expect(versions.first["version"]).to eq '3.14.1'
+    end
+  end
+
+  context 'when a regexp is provided and the last known version does not match' do
+    it 'produces the latest version matching the expression' do
+      versions = check('concourse/concourse', 'unmatched-version', '3.14.*')
+
+      expect(versions.length).to eq 1
+      expect(versions.first["version"]).to eq '3.14.1'
+    end
+  end
+
+  context 'when a regexp is provided and the last known version matches' do
+    it 'produces a list of versions matching the expression' do
+      versions = check('concourse/concourse', '3.14.0', '3.14.*')
+
+      expect(versions.length).to be > 0
+      expect(versions[0]["version"]).to eq '3.14.0'
+      expect(versions[1]["version"]).to eq '3.14.1'
     end
   end
 end


### PR DESCRIPTION
* While adding this feature we realised that we could not run the tests because building with alpine:edge resulted with an error. So we included this fix as well.

This also addresses https://github.com/concourse/bosh-io-release-resource/issues/14

cc @crsimmons