### PR TITLE
fix README so copy-pasters get a bosh release that updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ resources:
 - name: concourse
   type: bosh-io-release
   source:
-    repository: concourse/concourse
+    repository: concourse/concourse-bosh-release
 ```
 
 


### PR DESCRIPTION
bosh.io doesn't seem to track new releases at concourse/concourse, but works fine for the concourse-bosh-release repo.