### PR TITLE
Fix alpine image

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,4 +23,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.15.4
+   2.1.4


### PR DESCRIPTION
- Building the image was failing with the following bundler error

  `Could not find 'bundler' (1.15.4) required by your
  /resource/Gemfile.lock. (Gem::GemNotFoundException)`

  Updating the bundler version to the newer one available in the image
  solved the problem.

Signed-off-by: Sameer Vohra <svohra@pivotal.io>
Co-authored-by: Sameer Vohra <svohra@pivotal.io>