### PR TITLE
Fix ubuntu image

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 ADD . /resource
 WORKDIR /resource
+RUN gem update --system && gem install bundler #switch to bundle 2.1.4
 RUN bundle install --local \
   && bundle exec rspec
 FROM resource


### PR DESCRIPTION
- we updated the Gemfile.lock in the alpine image to use the newer
version of bundle, which resulted in breaking the ubuntu iamge. This
change here bumps the ubuntu image to using the latest version of bundle
to resolve the problem.

Signed-off-by: Sameer Vohra <svohra@pivotal.io>
Co-authored-by: Sameer Vohra <svohra@pivotal.io>