### PR TITLE
add sha256 when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Fetches a given release, placing the following in the destination:
 * `version`: The version number of the release.
 * `url`: A URL that can be used to download the release tarball.
 * `sha1`: The sha1 of the release tarball.
+* `sha256`: The sha256 of the release tarball.
 * `release.tgz`: The release tarball, if the `tarball` param is `true`.
 
 #### Parameters

--- a/assets/in
+++ b/assets/in
@@ -46,6 +46,7 @@ curl \
 
 url="$(jq -r .url < $release_data)"
 sha1="$(jq -r .sha1 < $release_data)"
+sha256="$(jq -r '.sha256 // "null"' < $release_data)"
 
 if [ "$url" = "null" ]; then
   echo "version $version not found; aborting"
@@ -55,18 +56,26 @@ fi
 echo "$url" > $destination/url
 echo "$version" > $destination/version
 echo "$sha1" > $destination/sha1
+if ! [ "$sha256" = "null" ]; then
+  echo "$sha256" > $destination/sha256
+fi
 
 if [ "$fetch_tarball" = "true" ]; then
   pushd $destination >/dev/null
     curl --retry 5 --fail -L "$url" -o release.tgz
-    echo "$sha1  release.tgz" | sha1sum -c -
+    if [ "$sha256" = "null" ]; then
+      echo "$sha1  release.tgz" | sha1sum -c -
+    else
+      echo "$sha256  release.tgz" | sha256sum -c -
+    fi
   popd >/dev/null
 fi
 
 jq -n '{
   version: { version: $version },
-  metadata: [
+  metadata: ([
     { name: "url", value: $url },
-    { name: "sha1", value: $sha1 }
-  ]
-}' --arg version "$version" --arg url "$url" --arg sha1 "$sha1" >&3
+    { name: "sha1", value: $sha1 },
+    { name: "sha256", value: $sha256 }
+  ] | map(select(.value != "null")))
+}' --arg version "$version" --arg url "$url" --arg sha1 "$sha1" --arg sha256 "$sha256" >&3

--- a/spec/in_spec.rb
+++ b/spec/in_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'in' do
   end
 
   context 'when specifying a version' do
-    it 'downloads the file and produces metadata' do
+    it 'downloads the file and produces metadata with only sha1 available' do
       response = get('cloudfoundry/os-conf-release', '16')
 
       file = File.join(destination, 'release.tgz')
@@ -32,6 +32,20 @@ RSpec.describe 'in' do
       expect(response['metadata']).to eq [
         {"name" => "url", "value" => "https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=16"},
         {"name" => "sha1", "value" => "8eeb72421ec94f2f9aedc50554b899d383e1d9a2"}
+      ]
+    end
+    it 'downloads the file and produces metadata with sha1 and sha256 available' do
+      response = get('cloudfoundry/os-conf-release', '20')
+
+      file = File.join(destination, 'release.tgz')
+      expect(File.exists?(file)).to be true
+      expect(Digest::SHA1.hexdigest File.read(file)).to eq '42b1295896c1fbcd36b55bfdedfe86782b2c9fba'
+      expect(Digest::SHA256.hexdigest File.read(file)).to eq '05b99381a231cc4de54cabf6134bef75ab85aa851173f337f47c644c33f95238'
+
+      expect(response['metadata']).to eq [
+        {"name" => "url", "value" => "https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=20"},
+        {"name" => "sha1", "value" => "42b1295896c1fbcd36b55bfdedfe86782b2c9fba"},
+        {"name" => "sha256", "value" => "05b99381a231cc4de54cabf6134bef75ab85aa851173f337f47c644c33f95238"}
       ]
     end
   end


### PR DESCRIPTION
we added sha256 information to the bosh.io api for stemcells and releases.
with this pr we can also retrieve the sha256

this pr is dependent on on https://github.com/bosh-io/web/pull/52