### PR TITLE
updates static-curl to the latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ FROM ${builder_image} AS tests
 USER root
 RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
 RUN apt update && apt install -y --no-install-recommends \
-    wget \
-    curl \
-    ca-certificates \
-    jq \
-    ruby-full \
+  wget \
+  curl \
+  ca-certificates \
+  jq \
+  ruby-full \
   && rm -rf /var/lib/apt/lists/*
 ADD assets/ /opt/resource/
-RUN wget "https://github.com/moparisthebest/static-curl/releases/download/v8.4.0/curl-amd64" -O /opt/resource/curl
+RUN wget "https://github.com/moparisthebest/static-curl/releases/download/v8.10.1/curl-amd64" -O /opt/resource/curl
 RUN chmod +x /opt/resource/*
 ADD . /resource
 WORKDIR /resource

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt update && apt install -y --no-install-recommends \
   ruby-full \
   && rm -rf /var/lib/apt/lists/*
 ADD assets/ /opt/resource/
-RUN wget "https://github.com/moparisthebest/static-curl/releases/download/v8.10.1/curl-amd64" -O /opt/resource/curl
+RUN wget "https://github.com/moparisthebest/static-curl/releases/download/v8.11.0/curl-amd64" -O /opt/resource/curl
 RUN chmod +x /opt/resource/*
 ADD . /resource
 WORKDIR /resource


### PR DESCRIPTION
This PR updates https://github.com/moparisthebest/static-curl to the latest release version.