### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,12 @@ will stop the build.
 Run the tests with the following command:
 
 ```sh
-docker build -t bosh-io-release-resource --target tests .
+docker build -t bosh-io-release-resource --build-arg BUILDPLATFORM=<platform> --target tests .
 ```
+Where `<platform>` is one of:
+- linux/arm64/v8 - Build an image for Linux running on a 64-bit ARM v8 processor (e.g., Apple Silicon Mac).
+- windows/amd64 - Build an image for Windows running on a 64-bit Intel x86_64 processor.
+- darwin/amd64 -  Build an image for macOS running on a 64-bit Intel x86_64 processor
 
 ### Contributing
 

--- a/assets/in
+++ b/assets/in
@@ -61,11 +61,17 @@ fi
 
 if [ "$fetch_tarball" = "true" ]; then
   ( cd $destination
-    curl --retry 5 --fail -L "$url" -o release.tgz
-    if [ "$sha256" = "null" ]; then
-      echo "$sha1  release.tgz" | sha1sum -c -
+    if [ "$preserve_filename" = "true" ]; then
+      curl --retry 5 --fail -L "$url"
     else
-      echo "$sha256  release.tgz" | sha256sum -c -
+      curl --retry 5 --fail -L "$url" -o release.tgz
+    fi
+
+    RELEASE_FILE=$(find . -maxdepth 1 -type f -name "*.tgz" | head -n 1)
+    if [ "$sha256" = "null" ]; then
+      echo "$sha1  $RELEASE_FILE" | sha1sum -c -
+    else
+      echo "$sha256  $RELEASE_FILE" | sha256sum -c -
     fi
   )
 fi


### PR DESCRIPTION
I run arch btw...  `docker build -t bosh-io-release-resource --target tests .` fails due to the following error message:
```
$ docker build -t bosh-io-release-resource --target tests .
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

Sending build context to Docker daemon  1.417MB
Step 1/10 : ARG base_image=cgr.dev/chainguard/wolfi-base
Step 2/10 : ARG BUILDPLATFORM
Step 3/10 : FROM --platform=${BUILDPLATFORM} ${base_image} AS tests
failed to parse platform : "" is an invalid OS component of "": OSAndVersion specifier component must match "^([A-Za-z0-9_-]+)(?:\\(([A-Za-z0-9_.-]*)\\))?$": invalid argument
(base)                                                              
```

Adding required parameter to actually run the test on linux and other os.